### PR TITLE
CommandSignature assert fix

### DIFF
--- a/Common_3/Renderer/Direct3D12/Direct3D12.cpp
+++ b/Common_3/Renderer/Direct3D12/Direct3D12.cpp
@@ -5449,7 +5449,6 @@ namespace d3d12 {
 	{
 		ASSERT(pRenderer);
 		ASSERT(pDesc);
-		ASSERT(pDesc->pRootSignature);
 		ASSERT(pDesc->pArgDescs);
 
 		CommandSignature* pCommandSignature = (CommandSignature*)conf_calloc(1, sizeof(*pCommandSignature));
@@ -5517,6 +5516,11 @@ namespace d3d12 {
 				ASSERT(false);
 				break;
 			}
+		}
+
+		if(change)
+		{
+			ASSERT(pDesc->pRootSignature);
 		}
 
 		commandStride = round_up(commandStride, 16);


### PR DESCRIPTION
addIndirectCommandSignature - set the assert for detecting a null root signature only when it is needed. When creating default command signatures for draw, drawIndexed & dispatch, having the root signature is not needed and shouldn't assert when this is the case.