### PR TITLE
Debugger fix for Path type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@
 **.vcxproj.user
 **.user
 **.log
+*.tlog
 
 # Art
 Art/
@@ -58,3 +59,9 @@ Art/
 # Nuget packages
 Tools/ShaderBuildCommand/packages/
 **/ThirdParty/OpenSource/hlslparser/Ext/ShaderTranslator/packages/
+
+# Shader cache binary
+*.bin
+
+# Microsoft Debug information
+*.pdb

--- a/Common_3/OS/Core/String.h
+++ b/Common_3/OS/Core/String.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018-2020 The Forge Interactive Inc.
+ *
+ * This file is part of The-Forge
+ * (see https://github.com/ConfettiFX/The-Forge).
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*/
+
+#pragma once
+#include "Atomics.h" // for tfrg_atomicptr_t
+
+// MARK: - Path
+
+// Paths are always formatted in the native format of their file system.
+// They never contain a trailing slash unless they are a root path.
+//
+// Implementation note: Paths must always be heap-allocated in mutable memory,
+// since we cast away their const-ness in fsCopyPath.
+// Doing so for a Path that is not allocated in writable heap memory is undefined
+// behaviour.
+struct Path
+{
+	struct FileSystem*         pFileSystem;
+	tfrg_atomicptr_t    mRefCount;
+	size_t              mPathLength;
+	char                mPathBufferOffset;
+	// ... plus a heap allocated UTF-8 buffer of length pathLength.
+};

--- a/Common_3/OS/FileSystem/FileSystemInternal.h
+++ b/Common_3/OS/FileSystem/FileSystemInternal.h
@@ -27,6 +27,7 @@
 
 #include "../Interfaces/IFileSystem.h"
 #include "../Core/Atomics.h"
+#include "../Core/String.h"
 
 // Include the functions to set the log file directory and executable name
 // for the memory manager.
@@ -76,24 +77,6 @@ struct FileSystem
 	virtual void
 		EnumerateSubDirectories(const Path* directory, bool (*processDirectory)(const Path*, void* userData), void* userData) const = 0;
 };
-
-// MARK: - Path
-
-// Paths are always formatted in the native format of their file system.
-// They never contain a trailing slash unless they are a root path.
-//
-// Implementation note: Paths must always be heap-allocated in mutable memory,
-// since we cast away their const-ness in fsCopyPath.
-// Doing so for a Path that is not allocated in writable heap memory is undefined
-// behaviour.
-typedef struct Path
-{
-	FileSystem*         pFileSystem;
-	tfrg_atomicptr_t    mRefCount;
-	size_t              mPathLength;
-	char                mPathBufferOffset;
-	// ... plus a heap allocated UTF-8 buffer of length pathLength.
-} Path;
 
 static inline size_t fsSizeOfPath(const Path* path) { return sizeof(Path) + path->mPathLength; }
 

--- a/Common_3/OS/Interfaces/IFileSystem.h
+++ b/Common_3/OS/Interfaces/IFileSystem.h
@@ -26,13 +26,13 @@
 #define IFileSystem_h
 
 #include "../Interfaces/IOperatingSystem.h"
+#include "../Core/String.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct FileSystem FileSystem;
-typedef struct Path Path;
 typedef struct FileStream FileStream;
 typedef void (*FileDialogCallbackFn)(const Path* path, void* userData);
 

--- a/Common_3/OS/Interfaces/IOperatingSystem.h
+++ b/Common_3/OS/Interfaces/IOperatingSystem.h
@@ -62,6 +62,7 @@ typedef uint64_t uint64;
 #include <stdio.h>
 #include <stdint.h>
 #include "../../OS/Math/MathTypes.h"
+#include "../Core/String.h"
 
 // For time related functions such as getting localtime
 #include <time.h>
@@ -249,8 +250,6 @@ float2       getDpiScale();
 bool getResolutionSupport(const MonitorDesc* pMonitor, const Resolution* pRes);
 
 // Shell commands
-
-typedef struct Path Path;
 
 /// @param stdOutFile The file to which the output of the command should be written. May be NULL.
 int systemRun(const char *command, const char **arguments, size_t argumentCount, const Path* stdOutFile);

--- a/Common_3/OS/Windows/OS.natvis
+++ b/Common_3/OS/Windows/OS.natvis
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?> 
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="Path">
+    <DisplayString>String: {(char*)&amp;mPathBufferOffset, s}</DisplayString>
+    <StringView>(char*)&amp;mPathBufferOffset, s</StringView>
+  </Type>
+</AutoVisualizer>

--- a/Examples_3/Ephemeris/PC Visual Studio 2017/Libraries/OS/OS.vcxproj
+++ b/Examples_3/Ephemeris/PC Visual Studio 2017/Libraries/OS/OS.vcxproj
@@ -74,6 +74,7 @@
     <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\Compiler.h" />
     <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\GPUConfig.h" />
     <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\RingBuffer.h" />
+	<ClInclude Include="..\..\..\..\..\Common_3\OS\Core\String.h" />
     <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\ThreadSystem.h" />
     <ClInclude Include="..\..\..\..\..\Common_3\OS\FileSystem\FileSystemInternal.h" />
     <ClInclude Include="..\..\..\..\..\Common_3\OS\FileSystem\MemoryStream.h" />
@@ -108,6 +109,7 @@
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="..\..\..\..\..\Common_3\ThirdParty\OpenSource\EASTL\EASTL.natvis" />
+	<Natvis Include="..\..\..\..\..\Common_3\OS\Windows\OS.natvis" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{30DD3D57-0026-48C8-BFD1-6392F319E23A}</ProjectGuid>

--- a/Examples_3/Ephemeris/PC Visual Studio 2017/Libraries/OS/OS.vcxproj.filters
+++ b/Examples_3/Ephemeris/PC Visual Studio 2017/Libraries/OS/OS.vcxproj.filters
@@ -203,6 +203,9 @@
     <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\RingBuffer.h">
       <Filter>OS\Core</Filter>
     </ClInclude>
+	<ClInclude Include="..\..\..\..\..\Common_3\OS\Core\String.h">
+      <Filter>OS\Core</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\ThreadSystem.h">
       <Filter>OS\Core</Filter>
     </ClInclude>
@@ -299,6 +302,9 @@
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="..\..\..\..\..\Common_3\ThirdParty\OpenSource\EASTL\EASTL.natvis">
+      <Filter>Utils</Filter>
+    </Natvis>
+	<Natvis Include="..\..\..\..\..\Common_3\OS\Windows\OS.natvis">
       <Filter>Utils</Filter>
     </Natvis>
   </ItemGroup>

--- a/Examples_3/Ephemeris/UbuntuCodelite/OSBase/OSBase.project
+++ b/Examples_3/Ephemeris/UbuntuCodelite/OSBase/OSBase.project
@@ -44,6 +44,7 @@
     <File Name="../../../../Common_3/OS/Core/Compiler.h"/>
     <File Name="../../../../Common_3/OS/Core/DLL.h"/>
     <File Name="../../../../Common_3/OS/Core/RingBuffer.h"/>
+	<File Name="../../../../Common_3/OS/Core/String.h"/>
     <File Name="../../../../Common_3/OS/Core/ThreadSystem.cpp"/>
     <File Name="../../../../Common_3/OS/Core/ThreadSystem.h"/>
     <File Name="../../../../Common_3/OS/Core/Timer.cpp"/>

--- a/Examples_3/Unit_Tests/Android_VisualStudio2017/Libraries/OS/OS.vcxproj
+++ b/Examples_3/Unit_Tests/Android_VisualStudio2017/Libraries/OS/OS.vcxproj
@@ -68,6 +68,7 @@
     <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\Compiler.h" />
     <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\GPUConfig.h" />
     <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\RingBuffer.h" />
+	<ClInclude Include="..\..\..\..\..\Common_3\OS\Core\String.h" />
     <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\ThreadSystem.h" />
     <ClInclude Include="..\..\..\..\..\Common_3\OS\FileSystem\FileSystemInternal.h" />
     <ClInclude Include="..\..\..\..\..\Common_3\OS\FileSystem\MemoryStream.h" />
@@ -111,6 +112,7 @@
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="..\..\..\..\..\Common_3\ThirdParty\OpenSource\EASTL\EASTL.natvis" />
+	<Natvis Include="..\..\..\..\..\Common_3\OS\Windows\OS.natvis" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3062376a-ea3d-4573-9a3f-cefdbe63c3aa}</ProjectGuid>

--- a/Examples_3/Unit_Tests/Android_VisualStudio2017/Libraries/OS/OS.vcxproj.filters
+++ b/Examples_3/Unit_Tests/Android_VisualStudio2017/Libraries/OS/OS.vcxproj.filters
@@ -239,6 +239,9 @@
     <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\RingBuffer.h">
       <Filter>OS\Core</Filter>
     </ClInclude>
+	<ClInclude Include="..\..\..\..\..\Common_3\OS\Core\String.h">
+      <Filter>OS\Core</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\ThreadSystem.h">
       <Filter>OS\Core</Filter>
     </ClInclude>
@@ -363,6 +366,9 @@
   <ItemGroup>
     <Natvis Include="..\..\..\..\..\Common_3\ThirdParty\OpenSource\EASTL\EASTL.natvis">
       <Filter>utils</Filter>
+    </Natvis>
+	<Natvis Include="..\..\..\..\..\Common_3\OS\Windows\OS.natvis">
+      <Filter>Utils</Filter>
     </Natvis>
   </ItemGroup>
 </Project>

--- a/Examples_3/Unit_Tests/PC Visual Studio 2017/Libraries/OS/OS.vcxproj
+++ b/Examples_3/Unit_Tests/PC Visual Studio 2017/Libraries/OS/OS.vcxproj
@@ -73,6 +73,7 @@
     <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\Compiler.h" />
     <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\GPUConfig.h" />
     <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\RingBuffer.h" />
+    <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\String.h" />
     <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\ThreadSystem.h" />
     <ClInclude Include="..\..\..\..\..\Common_3\OS\FileSystem\FileSystemInternal.h" />
     <ClInclude Include="..\..\..\..\..\Common_3\OS\FileSystem\MemoryStream.h" />
@@ -120,6 +121,7 @@
     <ClCompile Include="..\..\..\..\..\Common_3\OS\Windows\WindowsThread.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <Natvis Include="..\..\..\..\..\Common_3\OS\Windows\OS.natvis" />
     <Natvis Include="..\..\..\..\..\Common_3\ThirdParty\OpenSource\EASTL\EASTL.natvis" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/Examples_3/Unit_Tests/PC Visual Studio 2017/Libraries/OS/OS.vcxproj.filters
+++ b/Examples_3/Unit_Tests/PC Visual Studio 2017/Libraries/OS/OS.vcxproj.filters
@@ -195,6 +195,9 @@
     <ClInclude Include="..\..\..\..\..\Common_3\OS\FileSystem\MemoryStream.h">
       <Filter>OS\FileSystem</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\..\..\Common_3\OS\Core\String.h">
+      <Filter>OS\Core</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\..\Common_3\OS\Windows\WindowsBase.cpp">
@@ -344,6 +347,9 @@
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="..\..\..\..\..\Common_3\ThirdParty\OpenSource\EASTL\EASTL.natvis">
+      <Filter>Utils</Filter>
+    </Natvis>
+    <Natvis Include="..\..\..\..\..\Common_3\OS\Windows\OS.natvis">
       <Filter>Utils</Filter>
     </Natvis>
   </ItemGroup>

--- a/Examples_3/Visibility_Buffer/UbuntuCodelite/OSBase/OSBase.project
+++ b/Examples_3/Visibility_Buffer/UbuntuCodelite/OSBase/OSBase.project
@@ -48,6 +48,7 @@
     <File Name="../../../../Common_3/OS/Core/Compiler.h"/>
     <File Name="../../../../Common_3/OS/Core/DLL.h"/>
     <File Name="../../../../Common_3/OS/Core/RingBuffer.h"/>
+	<File Name="../../../../Common_3/OS/Core/String.h"/>
     <File Name="../../../../Common_3/OS/Core/ThreadSystem.h"/>
     <File Name="../../../../Common_3/OS/Core/ThreadSystem.cpp"/>
     <File Name="../../../../Common_3/OS/Core/Timer.cpp"/>


### PR DESCRIPTION
* ADD: OS.natvis with "Path" type visualization
* FIX: Moved Path type to separate header, to avoid conflicts with self forward declaration during PDB creation.