### PR TITLE
Fix iOS Xcode Open GL ES Error breakpoint crash.

### DIFF
--- a/Common_3/Renderer/OpenGLES/GLES.cpp
+++ b/Common_3/Renderer/OpenGLES/GLES.cpp
@@ -2825,17 +2825,17 @@ void gl_cmdBindRenderTargets(
 		}
 	}
 
-	if (clearMask)
-	{
-		CHECK_GLRESULT(glClear(clearMask));
-	}
-
 #if defined(ENABLE_GRAPHICS_DEBUG)
 	GLenum result;
 	CHECK_GL_RETURN_RESULT(result, glCheckFramebufferStatus(GL_FRAMEBUFFER));
 	if (result != GL_FRAMEBUFFER_COMPLETE && result != GL_NO_ERROR)
-LOGF(eERROR, "Incomplete framebuffer! %s", util_get_enum_string(result));
+		LOGF(eERROR, "Incomplete framebuffer! %s", util_get_enum_string(result));
 #endif
+	
+	if (clearMask)
+	{
+		CHECK_GLRESULT(glClear(clearMask));
+	}
 }
 
 void gl_cmdSetShadingRate(Cmd* pCmd, ShadingRate shadingRate, Texture* pTexture, ShadingRateCombiner postRasterizerRate, ShadingRateCombiner finalRate)


### PR DESCRIPTION
It will hit breakpoint crash when running GL ES backend with EAGLContext API 3.0 on iPhone XR without proper setting up framebuffer and renderbuffer from CAEAGLLayer storage.
It will show error message by changing place of `glCheckFramebufferStatus()` instead crashing instantly.