### PR TITLE
Remove redundant `waitQueueIdle()` except Android platform.

### DIFF
--- a/Common_3/OS/Fonts/FontSystem.cpp
+++ b/Common_3/OS/Fonts/FontSystem.cpp
@@ -610,7 +610,7 @@ void _Impl_FontStash::fonsImplementationRenderText(
 	if (ctx->mUpdateTexture)
 	{
 		// #TODO: Investigate - Causes hang on low-mid end Android phones (tested on Samsung Galaxy A50s)
-#ifndef __ANDROID__
+#ifdef __ANDROID__
 		waitQueueIdle(pCmd->pQueue);
 #endif
 


### PR DESCRIPTION
iPhone XR works fine without `waitQueueIdle()`. 
It should limit to Android devices according to the comment.