### PR TITLE
Fix Xcode 13.1 macOS compile error

### DIFF
--- a/Common_3/OS/Darwin/macOSBase.mm
+++ b/Common_3/OS/Darwin/macOSBase.mm
@@ -308,7 +308,7 @@ void AutoHideMenuBar()
 	CVDisplayLinkRef displayLink;
 	CAMetalLayer*    metalLayer;
 }
-@property(weak) id<RenderDestinationProvider> delegate;
+@property(assign) id<RenderDestinationProvider> delegate;
 
 - (id)initWithFrame:(NSRect)FrameRect device:(id<MTLDevice>)device display:(int)displayID hdr:(bool)hdr vsync:(bool)vsync;
 - (CVReturn)getFrameForTime:(const CVTimeStamp*)outputTime;


### PR DESCRIPTION
macOS compile error: cannot synthesize weak property in file using manual reference counting

The The-Forge.xcodeproj has set `Weak References in Manual Retain Release (CLANG_ENABLE_OBJC_WEAK)` to `YES`.

Following the step I try to add `set(CMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_WEAK "YES")` to CMakeLists.txt which does not fix the above error.     

Back to origin `assign` equals to `weak` here.

Moreover new project created by Xcode 13 shows the default value of `Weak References in Manual Retain Release (CLANG_ENABLE_OBJC_WEAK)` is `NO`.