### PR TITLE
chore: add assertion for vk_addSwapChain

### DIFF
--- a/Common_3/Renderer/Vulkan/Vulkan.cpp
+++ b/Common_3/Renderer/Vulkan/Vulkan.cpp
@@ -3597,6 +3597,7 @@ void vk_addSwapChain(Renderer* pRenderer, const SwapChainDesc* pDesc, SwapChain*
 	ASSERT(pDesc);
 	ASSERT(ppSwapChain);
 	ASSERT(pDesc->mImageCount <= MAX_SWAPCHAIN_IMAGES);
+	ASSERT(pDesc->ppPresentQueues);
 
 #if defined(QUEST_VR)
     hook_add_swap_chain(pRenderer, pDesc, ppSwapChain);


### PR DESCRIPTION
an access to ppPresentQueues happens on line 3775 its unguarded so an assertion here should help if a Queue is not provided when pDesc is passed in. 

```
	uint32_t      queue_family_indices[2] = { pDesc->ppPresentQueues[0]->mVulkan.mVkQueueFamilyIndex, 0 };
```