### PR TITLE
Github Actions: Auto-retry VS2017 installation

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: Custom-Middleware
-        repository: ConfettiFX/Custom-Middleware
+        repository: ${{ github.repository_owner }}/Custom-Middleware
         ref: ${{ github.ref_name }}  # Checkout the Custom-Middleware branch with the same name as the The-Forge branch we're building
 
     - name: Install Android SDK

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -82,7 +82,11 @@ jobs:
       run: choco install vulkan-sdk --version 1.2.162.0
 
     - name: Install VS2017
-      run: choco install VisualStudio2017Community visualstudio2017-workload-nativedesktop visualstudio2017-workload-nativemobile
+      uses: nick-fields/retry@v2.8.1
+      with:
+        max_attempts: 3
+        timeout_minutes: 30
+        command: choco install VisualStudio2017Community visualstudio2017-workload-nativedesktop visualstudio2017-workload-nativemobile
 
     - name: Install Android Game Development Extension
       shell: pwsh

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: Custom-Middleware
-        repository: ConfettiFX/Custom-Middleware
+        repository: ${{ github.repository_owner }}/Custom-Middleware
         ref: ${{ github.ref_name }}  # Checkout the Custom-Middleware branch with the same name as the The-Forge branch we're building
 
     - name: Setup Python

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: Custom-Middleware
-        repository: ConfettiFX/Custom-Middleware
+        repository: ${{ github.repository_owner }}/Custom-Middleware
         ref: ${{ github.ref_name }}  # Checkout the Custom-Middleware branch with the same name as the The-Forge branch we're building
 
     - name: Setup Python

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: Custom-Middleware
-        repository: ConfettiFX/Custom-Middleware
+        repository: ${{ github.repository_owner }}/Custom-Middleware
         ref: ${{ github.ref_name }}  # Checkout the Custom-Middleware branch with the same name as the The-Forge branch we're building
 
     - name: Setup Python

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -34,7 +34,11 @@ jobs:
       run: choco install vulkan-sdk --version 1.2.162.0
 
     - name: Install VS2017
-      run: choco install VisualStudio2017Community visualstudio2017-workload-nativedesktop
+      uses: nick-fields/retry@v2.8.1
+      with:
+        max_attempts: 3
+        timeout_minutes: 30
+        command: choco install VisualStudio2017Community visualstudio2017-workload-nativedesktop
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.1


### PR DESCRIPTION
* Attempted fix for sporadic failures due to VS2017 failing to download workloads.
* Use the Custom-Middleware repo from the same owner as the TF repo where the action is running