### PR TITLE
fix missing header for _wrename

### DIFF
--- a/Common_3/OS/Windows/WindowsToolsFileSystem.cpp
+++ b/Common_3/OS/Windows/WindowsToolsFileSystem.cpp
@@ -24,6 +24,7 @@
 
 #include "../../Application/Config.h"
 
+#include <wchar.h>
 #include "shlobj.h"
 #include "commdlg.h"
 


### PR DESCRIPTION
Fixes a VS 2017 compilation error.