### PR TITLE
pRenderTarget->mDescriptors = pDesc->mDescriptors;

### DIFF
--- a/Common_3/Graphics/Direct3D11/Direct3D11.cpp
+++ b/Common_3/Graphics/Direct3D11/Direct3D11.cpp
@@ -1729,6 +1729,7 @@ void d3d11_addRenderTarget(Renderer* pRenderer, const RenderTargetDesc* pDesc, R
 	pRenderTarget->mSampleQuality = pDesc->mSampleQuality;
 	pRenderTarget->mFormat = pDesc->mFormat;
 	pRenderTarget->mClearValue = pDesc->mClearValue;
+	pRenderTarget->mDescriptors = pDesc->mDescriptors;
 
 	*ppRenderTarget = pRenderTarget;
 }

--- a/Common_3/Graphics/Direct3D12/Direct3D12.cpp
+++ b/Common_3/Graphics/Direct3D12/Direct3D12.cpp
@@ -3557,6 +3557,7 @@ void d3d12_addRenderTarget(Renderer* pRenderer, const RenderTargetDesc* pDesc, R
 	pRenderTarget->mSampleQuality = pDesc->mSampleQuality;
 	pRenderTarget->mFormat = pDesc->mFormat;
 	pRenderTarget->mClearValue = pDesc->mClearValue;
+	pRenderTarget->mDescriptors = pDesc->mDescriptors;
 
 	*ppRenderTarget = pRenderTarget;
 }

--- a/Common_3/Graphics/Metal/MetalRenderer.mm
+++ b/Common_3/Graphics/Metal/MetalRenderer.mm
@@ -2750,6 +2750,7 @@ void mtl_addRenderTarget(Renderer* pRenderer, const RenderTargetDesc* pDesc, Ren
 	pRenderTarget->mSampleCount = pDesc->mSampleCount;
 	pRenderTarget->mSampleQuality = pDesc->mSampleQuality;
 	pRenderTarget->mFormat = pDesc->mFormat;
+	pRenderTarget->mDescriptors = pDesc->mDescriptors;
 	
 #if defined(USE_MSAA_RESOLVE_ATTACHMENTS)
 	if (pDesc->mFlags & TEXTURE_CREATION_FLAG_CREATE_RESOLVE_ATTACHMENT)

--- a/Common_3/Graphics/OpenGLES/GLES.cpp
+++ b/Common_3/Graphics/OpenGLES/GLES.cpp
@@ -1489,6 +1489,7 @@ void gl_addRenderTarget(Renderer* pRenderer, const RenderTargetDesc* pDesc, Rend
 	pRenderTarget->mSampleQuality = pDesc->mSampleQuality;
 	pRenderTarget->mClearValue = pDesc->mClearValue;
 	pRenderTarget->mFormat = targetFormat;
+	pRenderTarget->mDescriptors = pDesc->mDescriptors;
 
 	*ppRenderTarget = pRenderTarget;
 }

--- a/Common_3/Graphics/Vulkan/Vulkan.cpp
+++ b/Common_3/Graphics/Vulkan/Vulkan.cpp
@@ -4890,6 +4890,7 @@ void vk_addRenderTarget(Renderer* pRenderer, const RenderTargetDesc* pDesc, Rend
 	pRenderTarget->mClearValue = pDesc->mClearValue;
     pRenderTarget->mVRMultiview = (pDesc->mFlags & TEXTURE_CREATION_FLAG_VR_MULTIVIEW) != 0;
     pRenderTarget->mVRFoveatedRendering = (pDesc->mFlags & TEXTURE_CREATION_FLAG_VR_FOVEATED_RENDERING) != 0;
+	pRenderTarget->mDescriptors = pDesc->mDescriptors;
 
 	// Unlike DX12, Vulkan textures start in undefined layout.
 	// To keep in line with DX12, we transition them to the specified layout manually so app code doesn't have to worry about this


### PR DESCRIPTION
Added this missing line:
pRenderTarget->mDescriptors = pDesc->mDescriptors;

Without this line, removeRenderTarget can calculate an incorrect handleCount for an array/3d render target, by not multiplying by depthOrArraySize. And over time the maximum RTV descriptor count can be used up and cause a crash.