### PR TITLE
Fix potential vulnerable cloned functions: Save stack space while handling errors

### DIFF
--- a/Common_3/Game/ThirdParty/OpenSource/lua-5.3.5/src/ldebug.c
+++ b/Common_3/Game/ThirdParty/OpenSource/lua-5.3.5/src/ldebug.c
@@ -657,8 +657,11 @@ l_noret luaG_runerror (lua_State *L, const char *fmt, ...) {
   va_start(argp, fmt);
   msg = luaO_pushvfstring(L, fmt, argp);  /* format message */
   va_end(argp);
-  if (isLua(ci))  /* if Lua function, add source:line information */
+  if (isLua(ci)) {  /* if Lua function, add source:line information */
     luaG_addinfo(L, msg, ci_func(ci)->p->source, currentline(ci));
+    setobjs2s(L, L->top - 2, L->top - 1);  /* remove 'msg' from the stack */
+    L->top--;
+  }
   luaG_errormsg(L);
 }
 

--- a/Common_3/Game/ThirdParty/OpenSource/lua-5.3.5/src/lvm.c
+++ b/Common_3/Game/ThirdParty/OpenSource/lua-5.3.5/src/lvm.c
@@ -490,8 +490,10 @@ void luaV_concat (lua_State *L, int total) {
       /* collect total length and number of strings */
       for (n = 1; n < total && tostring(L, top - n - 1); n++) {
         size_t l = vslen(top - n - 1);
-        if (l >= (MAX_SIZE/sizeof(char)) - tl)
+        if (l >= (MAX_SIZE/sizeof(char)) - tl) {
+          L->top = top - total;  /* pop strings to avoid wasting stack */
           luaG_runerror(L, "string length overflow");
+        }
         tl += l;
       }
       if (tl <= LUAI_MAXSHORTLEN) {  /* is result a short string? */
@@ -506,7 +508,7 @@ void luaV_concat (lua_State *L, int total) {
       setsvalue2s(L, top - n, ts);  /* create result */
     }
     total -= n-1;  /* got 'n' strings to create 1 new */
-    L->top -= n-1;  /* popped 'n' strings and pushed one */
+    L->top = top - (n - 1);  /* popped 'n' strings and pushed one */
   } while (total > 1);  /* repeat until only 1 result left */
 }
 


### PR DESCRIPTION
**Description**
This PR fixes a potential vulnerability in luaG_runerror() that was cloned from lua but did not receive the security patch. The original issue was reported and fixed under https://github.com/lua/lua/commit/42d40581dd919fb134c07027ca1ce0844c670daf.
This PR applies the same patch to eliminate the vulnerability.

References
https://nvd.nist.gov/vuln/detail/cve-2022-33099
https://github.com/lua/lua/commit/42d40581dd919fb134c07027ca1ce0844c670daf